### PR TITLE
Add patch to update sales_update_frequency to Monthly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,11 +8,16 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-# python, js indentation settings
-[{*.py,*.js,*.vue,*.css,*.scss,*.html}]
-indent_style = tab
+# pythonindentation settings
+[{*.py}]
+indent_style = space
 indent_size = 4
-max_line_length = 99
+max_line_length = 120
+
+[{*.js,*.vue,*.css,*.scss,*.html}]
+indent_style = space
+indent_size = 2
+max_line_length = 120
 
 # JSON files - mostly doctype schema files
 [{*.json}]

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ jspm_packages/
 
 # Aider AI Chat
 .aider*
+
+.frappe-semgrep/

--- a/frappe_optimizations/patches.txt
+++ b/frappe_optimizations/patches.txt
@@ -4,3 +4,5 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+
+frappe_optimizations.patches.v_16.sales_update_frequency

--- a/frappe_optimizations/patches/v_16/sales_update_frequency.md
+++ b/frappe_optimizations/patches/v_16/sales_update_frequency.md
@@ -1,0 +1,10 @@
+## Sales Update Frequency Configuration
+
+**Setting:** Selling Settings -> Sales Update Frequency in Company and Project -> Monthly
+
+**Purpose:** This setting is required to avoid deadlock issues during Sales Invoice submission.
+
+**Details:**
+- By setting the update frequency to "Monthly" instead of real-time updates, we reduce the frequency of updates to Company and Project documents
+- This prevents concurrent write operations that can cause deadlocks when multiple Sales Invoices are being submitted simultaneously
+- The monthly update batches the sales updates, significantly reducing database lock contention

--- a/frappe_optimizations/patches/v_16/sales_update_frequency.py
+++ b/frappe_optimizations/patches/v_16/sales_update_frequency.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	try:
+		frappe.db.set_single_value("Selling Settings", "sales_update_frequency", "Monthly")
+	except Exception:
+		print("Failed to set sales update frequency to Monthly")
+		pass


### PR DESCRIPTION
This pull request introduces a new patch to configure the sales update frequency setting in Frappe, aiming to reduce database deadlocks during Sales Invoice submissions. It also updates the `.editorconfig` file to standardize indentation and line length settings across different file types.

**Sales update frequency configuration:**

* Added a patch (`frappe_optimizations.patches.v_16.sales_update_frequency`) that sets the `sales_update_frequency` field in `Selling Settings` to "Monthly" to avoid deadlock issues during Sales Invoice submissions by batching updates and reducing database lock contention. 

**Code style and formatting:**

* Updated `.editorconfig` to use spaces instead of tabs for Python, JavaScript, Vue, CSS, SCSS, and HTML files, and increased the maximum line length to 120 for these file types.


See: https://github.com/rtCamp/frappe-optimizations/issues/6