### PR TITLE
 feat(frappe_optimizations): monkey patch Payment Entry get_currency_data and add docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,8 @@ repos:
     rev: 'v1.91.0'
     hooks:
       - id: semgrep-ci
+        additional_dependencies:
+        - setuptools>=65
         args: ['--config', './.frappe-semgrep/rules', '--config','r/python.lang.correctness','--error', '--skip-unknown-extensions', '--metrics','off']
 ci:
   autoupdate_schedule: weekly

--- a/frappe_optimizations/__init__.py
+++ b/frappe_optimizations/__init__.py
@@ -7,8 +7,10 @@ def monkey_patch():
 	update_coupon_code_count_monkey_patch()
 
 	from .monkey_patches.get_pricing_rules import get_pricing_rules_monkey_patch
+	from .monkey_patches.payment_entry_get_currency_data import get_currency_data_monkey_patch
 
 	get_pricing_rules_monkey_patch()
+	get_currency_data_monkey_patch()
 
 
 try:

--- a/frappe_optimizations/monkey_patches/payment_entry_get_currency_data.md
+++ b/frappe_optimizations/monkey_patches/payment_entry_get_currency_data.md
@@ -1,0 +1,62 @@
+# Payment Entry get_currency_data Monkey Patch
+
+## Problem Statement
+
+We needed a custom change in ERPNext Payment Entry function `get_currency_data()` without editing ERPNext core files directly.
+
+Direct core edits are difficult to maintain and can be overwritten during updates.
+
+## Original Issue
+
+The function in ERPNext core did not include our required argument in the `frappe.db.get_all()` query for fetching currency/exchange-rate metadata.
+
+We required this behavior:
+
+```python
+frappe.db.get_all(
+	doctype,
+	filters={"name": ["in", refdoc]},
+	fields=["name", "currency", "conversion_rate", "party_account_currency"],
+	ignore_ifnull=True,
+)
+```
+
+## Solution
+
+Implemented a runtime monkey patch in `frappe_optimizations` that replaces:
+
+- `erpnext.accounts.doctype.payment_entry.payment_entry.get_currency_data`
+
+with our app-level implementation.
+
+### Why this approach
+
+1. No direct ERPNext core modification
+2. Upgrade-safe customization path
+3. Centralized patch loading with existing optimization patches
+
+## Implementation
+
+### 1. Added patch module
+
+`frappe_optimizations/monkey_patches/payment_entry_get_currency_data.py`
+
+- Contains custom `get_currency_data()` implementation
+- Includes `get_currency_data_monkey_patch()` that assigns the function at runtime
+
+### 2. Registered startup patch
+
+In `frappe_optimizations/__init__.py`:
+
+- Imported `get_currency_data_monkey_patch`
+- Called it inside existing `monkey_patch()` loader
+
+## Impact
+
+- Core file remains untouched
+- Required `ignore_ifnull=True` behavior is now active via app patch
+- Patch is applied automatically during app import/startup
+
+## Notes
+
+- This follows the same monkey patch pattern already used in this app for pricing-rule optimizations.

--- a/frappe_optimizations/monkey_patches/payment_entry_get_currency_data.py
+++ b/frappe_optimizations/monkey_patches/payment_entry_get_currency_data.py
@@ -1,0 +1,34 @@
+import frappe
+
+
+def get_currency_data(outstanding_refdocs: list, company: str | None = None) -> dict:
+	"""Get currency and conversion data for a list of invoices."""
+	exc_rates = frappe._dict()
+	company_currency = frappe.db.get_value("Company", company, "default_currency") if company else None
+
+	for doctype in ["Sales Invoice", "Purchase Invoice", "Sales Order", "Purchase Order"]:
+		refdoc = [x.voucher_no for x in outstanding_refdocs if x.voucher_type == doctype]
+		if len(refdoc) == 0:
+			continue
+
+		for row in frappe.db.get_all(
+			doctype,
+			filters={"name": ["in", refdoc]},
+			fields=["name", "currency", "conversion_rate", "party_account_currency"],
+			ignore_ifnull=True,
+		):
+			exc_rates[row.name] = frappe._dict(
+				conversion_rate=row.conversion_rate,
+				currency=row.currency,
+				party_account_currency=row.party_account_currency,
+				company_currency=company_currency,
+			)
+
+	return exc_rates
+
+
+def get_currency_data_monkey_patch():
+	# nosemgrep
+	from erpnext.accounts.doctype.payment_entry import payment_entry
+
+	payment_entry.get_currency_data = get_currency_data  # nosemgrep


### PR DESCRIPTION
This pull request introduces a new monkey patch for the `get_currency_data` function used in ERPNext Payment Entry, ensuring upgrade-safe custom behavior without modifying ERPNext core files. The patch is integrated with the existing optimization patch loader and includes documentation for maintainability. Additionally, a dependency update is made to the pre-commit configuration.

**ERPNext Payment Entry Monkey Patch:**

* Added a new module `payment_entry_get_currency_data.py` that implements a custom `get_currency_data()` function, ensuring the `ignore_ifnull=True` parameter is used when fetching currency data for invoices. This behavior was not present in the ERPNext core implementation.
* Registered the monkey patch by importing and invoking `get_currency_data_monkey_patch()` in the `monkey_patch()` function within `frappe_optimizations/__init__.py`, so the patch is applied automatically at startup.
* Added a detailed documentation file `payment_entry_get_currency_data.md` explaining the problem, solution, and impact of the patch for future maintainers.

**Tooling and Dependency Updates:**

* Updated `.pre-commit-config.yaml` to add `setuptools>=65` as an additional dependency for the `semgrep-ci` hook, likely to resolve compatibility or packaging issues.