### PR TITLE
Add overwrite to prevent frappe.db.count calls for top tables during boot load

### DIFF
--- a/frappe_optimizations/__init__.py
+++ b/frappe_optimizations/__init__.py
@@ -16,6 +16,10 @@ def monkey_patch():
 
 	operator_map_func_in_monkey_patch()
 
+	from .monkey_patches.choose_top_doctypes import choose_top_doctypes_monkey_patch
+
+	choose_top_doctypes_monkey_patch()
+
 
 try:
 	monkey_patch()

--- a/frappe_optimizations/monkey_patches/choose_top_doctypes.md
+++ b/frappe_optimizations/monkey_patches/choose_top_doctypes.md
@@ -1,0 +1,83 @@
+# Choose Top Doctypes - N+1 Query Optimization
+
+This monkey patch optimizes `choose_top_doctypes()` in Frappe's `WorkspaceSidebar` by replacing per-doctype `COUNT(*)` queries with a single `INFORMATION_SCHEMA` lookup using the Frappe query builder.
+
+## Problem Statement
+
+The original `choose_top_doctypes()` function calls `frappe.db.count(doctype)` inside a loop — one `COUNT(*)` query per doctype:
+
+```python
+for doctype in doctype_names:
+    if not is_single_doctype(doctype) and not frappe.get_meta(doctype).is_virtual:
+        doctype_count_map[doctype] = frappe.db.count(doctype)
+```
+
+For a module with 20+ doctypes this fires 20+ individual queries, causing:
+- **N+1 query problem** — one round-trip per doctype
+- **Performance bottleneck** during sidebar auto-generation
+- **Higher DB load** proportional to the number of doctypes per module
+
+## Solution
+
+Replace the per-doctype loop with a single `INFORMATION_SCHEMA.TABLES` query that fetches approximate row counts for all tables at once, with `ORDER BY table_rows DESC LIMIT 3` pushed to the database.
+
+### Key Changes
+
+#### Before
+
+```python
+doctype_count_map = {}
+for doctype in doctype_names:
+    if not is_single_doctype(doctype) and not frappe.get_meta(doctype).is_virtual:
+        doctype_count_map[doctype] = frappe.db.count(doctype)  # N queries
+
+top_doctypes = [
+    name
+    for name, count in sorted(doctype_count_map.items(), key=lambda x: x[1], reverse=True)[:3]
+]
+```
+
+#### After
+
+```python
+info_schema = frappe.qb.Schema("information_schema")
+rows = (
+    frappe.qb.from_(info_schema.tables)
+    .select(info_schema.tables.table_name)
+    .where(
+        (info_schema.tables.table_schema == frappe.conf.db_name)
+        & (info_schema.tables.table_name.isin(table_names))
+    )
+    .orderby(info_schema.tables.table_rows, order=frappe.qb.desc)
+    .limit(doctype_limit)
+    .run(as_dict=True)
+)
+return [row["table_name"].removeprefix("tab") for row in rows]
+```
+
+#### `choose_top_doctypes_monkey_patch()`
+
+```python
+def choose_top_doctypes_monkey_patch() -> None:
+    # nosemgrep
+    from frappe.desk.doctype.workspace_sidebar import workspace_sidebar
+    workspace_sidebar.choose_top_doctypes = choose_top_doctypes  # nosemgrep
+```
+
+**Purpose**: Replace Frappe's original function with the optimized version  
+**Execution**: Automatically on app startup via `__init__.py`
+
+---
+
+## Performance Impact
+
+| | Before | After |
+|---|---|---|
+| DB Queries | N (one per doctype) | 1 |
+| Sorting | Python `sorted()` | `ORDER BY` in SQL |
+| Rows transferred | All doctypes | 3 (LIMIT) |
+| Count accuracy | Exact (`COUNT(*)`) | Approximate (InnoDB `TABLE_ROWS`) |
+
+`TABLE_ROWS` in `INFORMATION_SCHEMA` is an InnoDB row-count estimate. It is not exact but is sufficient for picking the top 3 most-used doctypes by relative size.
+
+> **Note**: Frappe's query builder handles Postgres transparently — `table_rows` is translated to `n_tup_ins` and `information_schema.tables` to `pg_stat_all_tables` automatically.

--- a/frappe_optimizations/monkey_patches/choose_top_doctypes.py
+++ b/frappe_optimizations/monkey_patches/choose_top_doctypes.py
@@ -1,0 +1,46 @@
+import frappe
+
+
+def choose_top_doctypes(doctype_names: list[str]) -> list[str] | None:
+	"""Return top doctypes by approximate row count using a single INFORMATION_SCHEMA query.
+
+	Replaces the original N+1 implementation that called frappe.db.count() per doctype.
+	INFORMATION_SCHEMA.TABLE_ROWS is an InnoDB estimate — accurate enough for ranking.
+	"""
+	from frappe.model.utils import is_single_doctype
+
+	doctype_limit = 3
+	if len(doctype_names) <= doctype_limit:
+		return None
+
+	try:
+		eligible = [
+			d for d in doctype_names if not is_single_doctype(d) and not frappe.get_meta(d).is_virtual
+		]
+		if not eligible:
+			return None
+
+		table_names = [f"tab{d}" for d in eligible]
+		info_schema = frappe.qb.Schema("information_schema")
+		rows = (
+			frappe.qb.from_(info_schema.tables)
+			.select(info_schema.tables.table_name)
+			.where(
+				(info_schema.tables.table_schema == frappe.conf.db_name)
+				& (info_schema.tables.table_name.isin(table_names))
+			)
+			.orderby(info_schema.tables.table_rows, order=frappe.qb.desc)
+			.limit(doctype_limit)
+			.run(as_dict=True)
+		)
+		# strip the "tab" prefix to get back to doctype names
+		return [row["table_name"].removeprefix("tab") for row in rows]
+	except frappe.db.ProgrammingError:
+		return None
+
+
+def choose_top_doctypes_monkey_patch() -> None:
+	# nosemgrep
+	from frappe.desk.doctype.workspace_sidebar import workspace_sidebar
+
+	workspace_sidebar.choose_top_doctypes = choose_top_doctypes  # nosemgrep


### PR DESCRIPTION
This pull request introduces a performance optimization for the `choose_top_doctypes` function in Frappe's `WorkspaceSidebar`. The main improvement is replacing the previous N+1 query pattern (one database query per doctype) with a single, more efficient query that retrieves approximate row counts for all relevant doctypes at once. This significantly reduces database load and improves sidebar generation speed. The change is implemented via a monkey patch that is applied automatically at app startup.

**N+1 Query Optimization:**

* Added a new implementation of `choose_top_doctypes` in `choose_top_doctypes.py` that uses a single `INFORMATION_SCHEMA` query to fetch approximate row counts for all eligible doctypes, replacing the previous approach that executed a separate `COUNT(*)` query for each doctype. This reduces the number of database queries from N to 1 and leverages SQL's `ORDER BY` and `LIMIT` for efficiency.
* The optimized function strips the `"tab"` prefix from table names to return the original doctype names and gracefully handles exceptions by returning `None` if the query fails.

**Monkey Patch Integration:**

* Introduced `choose_top_doctypes_monkey_patch`, which replaces the original `choose_top_doctypes` function in `workspace_sidebar` with the optimized version. This patch is invoked automatically during app initialization in `__init__.py`. [[1]](diffhunk://#diff-4f7756d83c27927479bfe98f5c9723167aaee42a59ea5c41fe2ce4cbae5a7b3fR1-R46) [[2]](diffhunk://#diff-e7fb6c68c86e3abde2d9208572f88b24201e56cb8f4bea0120cedfa6d34886b9R19-R22)

**Documentation:**

* Added a detailed markdown file (`choose_top_doctypes.md`) documenting the N+1 query problem, the new solution, code examples, and performance impact, including a comparison table and notes on database compatibility.